### PR TITLE
Add rtree calculation and overlap display to OCR UI

### DIFF
--- a/package.json
+++ b/package.json
@@ -184,7 +184,8 @@
     "@thi.ng/rle-pack": "^2.1.6",
     "babel-preset-react-app": "^9.1.1",
     "d3": "^5.16.0",
-    "magic-wand-js": "^1.0.0"
+    "magic-wand-js": "^1.0.0",
+    "rtree": "^1.4.2"
   },
   "nohoist": [
     "**/babel-preset-react-app/@babel/runtime"

--- a/src/stores/AnnotationStore.js
+++ b/src/stores/AnnotationStore.js
@@ -591,6 +591,27 @@ const Annotation = types
         value: resultValue,
       };
 
+      const foundText = getRoot(self).task.getTextFromBbox(areaValue.x, areaValue.y, areaValue.width, areaValue.height);
+      
+      let results;
+
+      if (foundText) {
+        const result2 = {
+          from_name: 'transcription',
+          to_name: 'image',
+          type: 'textarea',
+          value: {
+            text: [
+              foundText,
+            ],
+          },
+        };
+        
+        results = [result, result2];
+      } else {
+        results = [result];
+      }
+
       const areaRaw = {
         id: guidGenerator(),
         object,
@@ -598,7 +619,7 @@ const Annotation = types
         ...areaValue,
         // for Model detection
         value: areaValue,
-        results: [result],
+        results,
       };
 
       const area = self.areas.put(areaRaw);

--- a/src/stores/TaskStore.js
+++ b/src/stores/TaskStore.js
@@ -73,12 +73,14 @@ const TaskStore = types
         textAnnotations.forEach((box, index) => {
           if (index === 0)
             return;
-              
+          
+          const bbVertices = box.boundingPoly.vertices;
+
           bbrtree.insert({
-            x: box.boundingPoly.vertices[0].x,
-            y: box.boundingPoly.vertices[0].y,
-            w: box.boundingPoly.vertices[2].x - box.boundingPoly.vertices[0].x,
-            h: box.boundingPoly.vertices[2].y - box.boundingPoly.vertices[0].y,
+            x: bbVertices[0].x,
+            y: bbVertices[0].y,
+            w: bbVertices[2].x - bbVertices[0].x,
+            h: bbVertices[2].y - bbVertices[0].y,
           }, { description: box.description });
         });
 


### PR DESCRIPTION
- Added method to calculate bounding box overlap based on rectangles instead of polygons.
- Added functionality to show OCR text on OCR region textfield.

<img width="733" alt="Screen Shot 2021-08-18 at 9 48 56 AM" src="https://user-images.githubusercontent.com/86631684/129940332-4ef79a48-2065-4c65-b09f-92f6cb1be1b5.png">
