### PR TITLE
Remove object rotation from drawing tool.

### DIFF
--- a/src/mixins/DrawingToolExtension.js
+++ b/src/mixins/DrawingToolExtension.js
@@ -32,10 +32,10 @@ export const DrawingToolExtension = types.model().actions(self => ({
             y: bbox.area.y / scaleY,
             width: bbox.area.width / scaleX,
             height: bbox.area.height / scaleY,
-            rotation: obj.rotation,
+            rotation: 0,
             coordstype: "px",
           };
-
+ 
           const bboxNewArea = self.annotation.createResult(area, {}, control, obj, bbox.description);
 
           self.applyActiveStates(bboxNewArea);


### PR DESCRIPTION
Fixes annotation when rotated:
![image](https://user-images.githubusercontent.com/86631684/133499373-cbf3f2be-61ca-41ce-8ede-7c01aca979fd.png)
